### PR TITLE
Fixed an issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,15 +10,15 @@
     "axios": "^0.19.0",
     "formik": "^1.5.8",
     "moment": "^2.24.0",
-    "react": "^16.12.0",
+    "react": "^17.0.0",
     "react-bootstrap": "^1.0.0-beta.10",
     "react-dom": "^16.12.0",
     "react-redux": "^7.1.0",
     "react-router-dom": "^5.1.2",
-    "react-scripts": "3.3.0",
+    "react-scripts": "^3.4.1",
     "redux": "^4.0.4",
     "redux-thunk": "^2.3.0",
-    "typescript": "~3.7.2",
+    "typescript": "^3.9.2",
     "yup": "^0.27.0"
   },
   "scripts": {
@@ -43,6 +43,7 @@
     ]
   },
   "devDependencies": {
+    "@popperjs/core": "^2.9.2",
     "@types/enzyme": "^3.10.3",
     "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/moxios": "^0.4.8",


### PR DESCRIPTION
updates some package's so it has fixed issues

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined